### PR TITLE
Handle recreation of matching entries within debounce phase

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -69,7 +69,8 @@ impl Scanner {
                         match event {
                             DebouncedEvent::Create(p)
                             | DebouncedEvent::Chmod(p)
-                            | DebouncedEvent::Rename(_, p) => {
+                            | DebouncedEvent::Rename(_, p)
+                            | DebouncedEvent::Write(p) => {
                                 Self::handle_entry(self, p.as_path(), dry_run, &mut scanner_stats);
                             }
                             _ => {}


### PR DESCRIPTION
A deletion followed by a quick recreation within the 2 second debounce
phase was not handled.