### PR TITLE
Fix macOS configuration directory documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ After you have installed the binary you need to create a configuration file whic
 
 The configuration file locations are as follows:
 
-| System      | Location                                                           |
-| :---------- | :----------------------------------------------------------------- |
-| Linux dist. | `/home/charly/.config/dropignore/dropignore.yml`                   |
-| macOS       | `/Users/charly/Library/Preferences/dropignore/dropignore.yml`      |
-| Windows     | `C:\Users\charly\AppData\Roaming\dropignore\config\dropignore.yml` |
+| System      | Location                                                              |
+| :---------- | :-------------------------------------------------------------------- |
+| Linux dist. | `/home/charly/.config/dropignore/dropignore.yml`                      |
+| macOS       | `/Users/charly/Library/Application Support/dropignore/dropignore.yml` |
+| Windows     | `C:\Users\charly\AppData\Roaming\dropignore\config\dropignore.yml`    |
 
 The configuration file could look like this:
 


### PR DESCRIPTION
The directories (or rather dirs-sys) crate changed this to the
correct/recommended location a long while ago, but I missed the change.

Fixes #30.